### PR TITLE
Ensure that nav-drop item takes full height to prevent unintentional …

### DIFF
--- a/blocks/header/header.css
+++ b/blocks/header/header.css
@@ -132,7 +132,9 @@ header secondary-nav .nav-sections {
   display: none;
 }
 header secondary-nav .nav-sections > ul > li.nav-drop {
+  height: var(--nav-height);
   position: relative;
+  padding-top: 16px;
 }
 header secondary-nav .nav-sections > ul > li.nav-drop:first-child {
   font-family: 'Libre Franklin', Arial, Helvetica, sans-serif;
@@ -349,6 +351,8 @@ header .sticky {
     display: none;
   }
   header secondary-nav .nav-sections > ul > li:not(:first-child) {
+    height: var(--nav-height);
+    padding-top: 16px;
     display: unset;
   }
   header secondary-nav .nav-sections > ul > li > a::after {

--- a/blocks/header/header.less
+++ b/blocks/header/header.less
@@ -166,7 +166,9 @@ header {
 
 			>ul {
 				>li.nav-drop {
+					height: var(--nav-height);
 					position: relative;
+					padding-top: 16px;
 
 					&:first-child {
 						font-family: @nav-heading-first-child-font-family;
@@ -179,7 +181,6 @@ header {
 					&:not(:first-child) {
 						display: none;
 					}
-
 					position: relative;
 					font-size: 18px;
 					margin: 0;
@@ -442,6 +443,8 @@ header {
 						}
 
 						&:not(:first-child) {
+							height: var(--nav-height);
+							padding-top: 16px;
 							display: unset;
 						}
 


### PR DESCRIPTION
Ensure that nav-drop item takes full height to prevent unintentional mouseover/mouseleave events

Please always provide the [GitHub issue(s)](../issues) your PR is for, as well as test URLs where your change can be observed (before and after):

Fix #127 
https://user-images.githubusercontent.com/226514/227274972-7cb236c2-6d1d-436e-bea2-86053ac5760e.mov

Test URLs:
- Before: https://main--nedbank--hlxsites.hlx.live/content/nedbank/za/en/personal/home
- After: https://issue-127--nedbank--hlxsites.hlx.live/content/nedbank/za/en/personal/home
