### PR TITLE
Added null safety for querySearchModal

### DIFF
--- a/blocks/header/header.js
+++ b/blocks/header/header.js
@@ -57,8 +57,8 @@ function addLoginEventListener(nav) {
         window.scrollTo(0, 0); // Scrolling to Top
         bodyEle.classList.add('overflow-hidden');
         bodyEle.classList.remove('overflowY-hidden');
-        if (document.querySelector('#querySearchModal')) {
-          document.querySelector('#querySearchModal').classList.remove('show', 'appear');
+        if (document.getElementById('querySearchModal')) {
+          document.getElementById('querySearchModal').classList.remove('show', 'appear');
         }
       } else if (loginEle.classList.contains('modal')) {
         loginEle.classList.remove('modal');
@@ -127,7 +127,7 @@ async function delayedNavTools() {
         document.body.classList.remove('overflowY-hidden');
       } else {
         document.body.classList.add('overflowY-hidden');
-        document.querySelector('#querySearchModal').classList.remove('show', 'appear');
+        document.getElementById('querySearchModal').classList.remove('show', 'appear');
         document.querySelector('.login-overlay').classList.remove('modal');
         document.body.classList.remove('overflow-hidden');
       }

--- a/blocks/header/header.js
+++ b/blocks/header/header.js
@@ -57,7 +57,9 @@ function addLoginEventListener(nav) {
         window.scrollTo(0, 0); // Scrolling to Top
         bodyEle.classList.add('overflow-hidden');
         bodyEle.classList.remove('overflowY-hidden');
-        document.querySelector('#querySearchModal').classList.remove('show', 'appear');
+        if (document.querySelector('#querySearchModal')) {
+          document.querySelector('#querySearchModal').classList.remove('show', 'appear');
+        }
       } else if (loginEle.classList.contains('modal')) {
         loginEle.classList.remove('modal');
         bodyEle.classList.remove('overflow-hidden');
@@ -194,5 +196,5 @@ export default async function decorate(block) {
   block.append(navDiv);
 
   // Delayed load to reduct TBT impact
-  setTimeout(delayedNavTools, 3000);
+  // setTimeout(delayedNavTools, 3000);
 }

--- a/blocks/header/header.js
+++ b/blocks/header/header.js
@@ -196,5 +196,5 @@ export default async function decorate(block) {
   block.append(navDiv);
 
   // Delayed load to reduct TBT impact
-  // setTimeout(delayedNavTools, 3000);
+  setTimeout(delayedNavTools, 3000);
 }


### PR DESCRIPTION
Test URLs:
- Before: https://main--nedbank--hlxsites.hlx.live/
- After: https://null-safety--nedbank--hlxsites.hlx.live/

Problem happens if the "Login" button is clicked too soon even before there's a queryModal present in the markup.

```
caught TypeError: Cannot read properties of null (reading 'classList')
    at HTMLDivElement.<anonymous> (header.js:60:52)
(anonymous) @ header.js:60
la
```